### PR TITLE
fix: Accept all children in paragraph block

### DIFF
--- a/src/components/blocks/StrapiBlockParagraph.astro
+++ b/src/components/blocks/StrapiBlockParagraph.astro
@@ -21,7 +21,7 @@ const isNotEmpty = sanitizedData.length > 0;
 ---
 { isNotEmpty && (
     <>
-        { block && (<StrapiBlockCustom {...Astro.props} comp={block} data={sanitizedData[0]} />)}
+        { block && (<StrapiBlockCustom {...Astro.props} comp={block} data={sanitizedData} />)}
         { !block && (<p class={classes}>
             { isNotEmpty && (<SanitizedNode data={sanitizedData} theme={theme.paragraph}/>) }
         </p>)}


### PR DESCRIPTION
# Pull Request

## 📝 Description
It was not possible to render both text and link in the paragraph block, due to passing only the first element in the array of `sanitizedData`.

## 🔄 Changes
Passing the full array to `StrapiBlockCustom` to allow for both text and link to be rendered.

## 🧪 Testing
Locally/manually tested in my project.

## ✅ Checklist
- [X] I have read and followed the [Contributing Guidelines](CONTRIBUTING.md)
- [X] My changes follow the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added my changes to the [CHANGELOG.md](CHANGELOG.md)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## 🔗 Related Issues
<!-- Link to any related issues -->
Closes #<!-- Issue number --> 